### PR TITLE
Add key-value support

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -28,10 +28,16 @@ http {
 
     #gzip  on;
 
+    keyval_zone zone=zone_one:32k;
+    keyval $arg_text $text zone=zone_one;
+
     include /etc/nginx/conf.d/*.conf;
 }
 
 stream {
+    keyval_zone zone=zone_one_stream:32k;
+    keyval $hostname $text zone=zone_one_stream;
+
     upstream stream_test {
         zone stream_test 64k;
     }


### PR DESCRIPTION
Full support for key-value endpoints for both http and stream contexts.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
