### PR TITLE
Add lint option to Makefile and fix lint issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,4 @@ Note: if you’d like to implement a new feature, please consider creating a fea
 * Run `gofmt` over your code to automatically resolve a lot of style issues. Most editors support this running automatically when saving a code file.
 * Run `go lint` and `go vet` on your code too to catch any other issues.
 * Follow this guide on some good practice and idioms for Go -  https://github.com/golang/go/wiki/CodeReviewComments
+* To check for extra issues, install [golangci-lint](https://github.com/golangci/golangci-lint) and run `make lint` or `golangci-lint run`

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ NGINX_IMAGE=nginxplus:$(NGINX_PLUS_VERSION)
 
 test: docker-build run-nginx-plus test-run configure-no-stream-block test-run-no-stream-block clean
 
+lint:
+	golangci-lint run
+
 docker-build:
 	docker build --build-arg NGINX_PLUS_VERSION=$(NGINX_PLUS_VERSION)~stretch -t $(NGINX_IMAGE) docker
 

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -462,9 +462,6 @@ func TestStats(t *testing.T) {
 			if ups.Peers[0].State != "up" {
 				t.Errorf("upstream server state should be 'up'")
 			}
-			if ups.Peers[0].Responses.Total < 0 {
-				t.Errorf("upstream should have total responses value")
-			}
 			if ups.Peers[0].HealthChecks.LastPassed {
 				t.Errorf("upstream server health check should report last failed")
 			}


### PR DESCRIPTION
### Proposed changes
Add a Makefile option to run go linter in dev.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-go-sdk/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork
